### PR TITLE
refactor: removed load and store invariant code.

### DIFF
--- a/third_assignment/loopInvariantCodeMotion.hpp
+++ b/third_assignment/loopInvariantCodeMotion.hpp
@@ -3,14 +3,12 @@
 
 #include "llvm/IR/PassManager.h"
 #include "llvm/Analysis/LoopPass.h"
-#include "llvm/IR/Value.h"
-#include "llvm/IR/BasicBlock.h"
-#include "llvm/IR/Instructions.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/Transforms/Scalar/LoopPassManager.h"
 #include "llvm/IR/Dominators.h"
+#include "llvm/Analysis/ValueTracking.h"
 
 #include <vector>
 #include <algorithm>


### PR DESCRIPTION
Removed code related that managed invariant loads and stores, since we will expect to always have the mem2reg pass enabled before applying loop invariant code motion.

Changed the checks that were performed on loads and stores after loop invariant instructions detection. Now we just check instruction dominance during at the same time when we check loop invariance. A safety check was added using LLVM isSafeToSpeculativelyExecute function.

It closes #9 as it is the needed refactor